### PR TITLE
extend config parser to parse keys with a period `.` as subnamespaces

### DIFF
--- a/yamlparser/test/test_argparse.py
+++ b/yamlparser/test/test_argparse.py
@@ -19,6 +19,11 @@ class TestArgparse(unittest.TestCase):
                 "nested": {
                     "name": "subnested"
                 },
+            },
+            "some": {
+                "dot": {
+                    "attribute": 42
+                }
             }
         })
         self.assertEqual(namespace.dump(), expected.dump())

--- a/yamlparser/test/test_config.yaml
+++ b/yamlparser/test/test_config.yaml
@@ -13,3 +13,5 @@ nested:
 
     nested:
         name: subnested
+
+some.dot.attribute: 42

--- a/yamlparser/test/test_yaml.py
+++ b/yamlparser/test/test_yaml.py
@@ -164,5 +164,6 @@ class TestYaml(unittest.TestCase):
 
 
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I extended the `update` function to check if a key contains a period `.` in its name. If so, the part before the period gets processed as key and the rest gets treated as a new key value pair (and calls update recursively). This leads to attributes (e.g. "some.attribute") to be parsed as nested NameSpaces.

All tests pass -> does not seem to break any other functionality